### PR TITLE
Update build.gradle - Upgrade java version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,15 @@ android {
 
     compileSdkVersion 33
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+    
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
```
Execution failed for task ':facebook_app_events:compileDebugKotlin'.
  'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
```